### PR TITLE
Working solution (currently for one Type of Article: Feature)

### DIFF
--- a/app/controllers/admin/features_controller.rb
+++ b/app/controllers/admin/features_controller.rb
@@ -8,6 +8,27 @@ module Admin
     #   @resources = Feature.all.paginate(10, params[:page])
     # end
 
+    def create
+        resource_params = params.require(resource_name).permit(:title, 
+          :user_id, :article_content, :image, :publish_date_time, 
+          :type)
+
+        resource_params[:user_id] = current_user.id
+
+        resource = resource_class.new(resource_params)
+
+        if resource.save
+          redirect_to(  
+            [namespace, resource],
+            notice: translate_with_resource("create.success"),
+          )
+        else
+          render :new, locals: {
+            page: Administrate::Page::Form.new(dashboard, resource),
+          }
+        end
+    end
+
     # Define a custom finder by overriding the `find_resource` method:
     # def find_resource(param)
     #   Feature.find_by!(slug: param)

--- a/app/dashboards/feature_dashboard.rb
+++ b/app/dashboards/feature_dashboard.rb
@@ -51,7 +51,7 @@ class FeatureDashboard < Administrate::BaseDashboard
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = [
     :title,
-    :user,
+    # :user,
     :article_content,
     :image,
     :publish_date_time,

--- a/app/views/admin/features/_form.html.erb
+++ b/app/views/admin/features/_form.html.erb
@@ -1,0 +1,42 @@
+<%#
+# Form Partial
+
+This partial is rendered on a resource's `new` and `edit` pages,
+and renders all form fields for a resource's editable attributes.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<%= form_for([namespace, page.resource], html: { class: "form" }) do |f| %>
+  <% if page.resource.errors.any? %>
+    <div id="error_explanation">
+      <h2>
+        <%= pluralize(page.resource.errors.count, "error") %>
+        prohibited this <%= page.resource_name %> from being saved:
+      </h2>
+
+      <ul>
+        <% page.resource.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <% page.attributes.each do |attribute| -%>
+    <div class="field-unit field-unit--<%= attribute.html_class %>">
+      <%= render_field attribute, f: f %>
+    </div>
+  <% end -%>
+
+  <div class="form-actions">
+    <%= f.submit %>
+  </div>
+<% end %>

--- a/app/views/admin/features/new.html.erb
+++ b/app/views/admin/features/new.html.erb
@@ -1,0 +1,27 @@
+<%#
+# New
+
+This view is the template for the "new resource" page.
+It displays a header, and then renders the `_form` partial
+to do the heavy lifting.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Form][1].
+  Contains helper methods to help display a form,
+  and knows which attributes should be displayed in the resource's form.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Form
+%>
+
+<% content_for(:title) { "New #{page.resource_name.titleize}" } %>
+
+<header class="header">
+  <h1 class="header__heading"><%= content_for(:title) %></h1>
+  <div class="header__actions">
+    <%= link_to 'Back', :back, class: "button" %>
+  </div>
+</header>
+
+<%= render 'form', page: page %>


### PR DESCRIPTION
When a feature article is created it is assigned to the current user. Downside is that, right now, there is no way to edit it. 

To clarify: When I go to create a new Feature, there is no dropdown to select an author. I am automatically the author. This also means, however, that there is no drop down for an author when I go to edit the Feature.

> I _think_ this is a limitation of Administrate, though there is more I can read about having separate forms for creating and editing a resource.

 I went this route because, best I can tell, there is not a way to customize a drop down to have a preselected value...but I can dig a bit more on this.

Does this make sense for the way you see this admin dashboard being used, Michael? Or is it unhelpful?

Let me know and if you want to keep it, I can apply it to FAQs and Visitor Guides.
